### PR TITLE
relax it to allow social media data to be uploaded to clowder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Allow upload social media data to Clowder [#99](https://github.com/ncsa/standalone-smm-smile/issues/99)
+
 ## [0.3.0] - 2023-09-14
 ### Fixed
 - Github action to auto generate docker container [#93](https://github.com/ncsa/standalone-smm-smile/issues/93)

--- a/www/public/bootstrap/js/customized/view_helperFunc.js
+++ b/www/public/bootstrap/js/customized/view_helperFunc.js
@@ -551,11 +551,10 @@ function submitHistory(currItem, folderURL){
 
                     // ADD TO CLOWDER MODAL
                     $("#clowder-files-list").empty();
-                    if (data.title != 'Social Media'){
-                        clowderFileGen(data.download);
-                        clowderFileMeta();
-                        $('.fileTags').tagsinput({ freeInput: true });
-                    }
+                    clowderFileGen(data.download);
+                    clowderFileMeta();
+                    $('.fileTags').tagsinput({ freeInput: true });
+
 
                     if ('title' in data || 'ID' in data){
                         appendTitle(data.title, data.ID);


### PR DESCRIPTION
To Test:

- Use docker-compose
- Use this PR image 
- set CLOWDER_ON to be true
- Go to history page and try to upload social media data to clowder. You should be able to see files: e.g.
<img width="1645" alt="image" src="https://github.com/IllinoisSocialMediaMacroscope/smm-smile/assets/13950475/7cc9d649-2600-4610-a0f5-4e758961853d">

